### PR TITLE
Better support for Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@
 build/
 bin/
 gradle.properties
+
+# Eclipse
+.classpath
+.project
+.settings

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ version = "0.4.5"
 
 dependencies {
 	testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.5.2'
+	testRuntimeOnly "org.junit.platform:junit-platform-commons:1.7.0"
 }
 
 test {


### PR DESCRIPTION
This adds Eclipse project files to the `.gitignore` so people don't have to manually add it to their `.git/info/exclude` file.

It also adds a missing JUnit dependency. Without this dependency, unit tests fail with a `ClassNotFoundException` when running from within Eclipse.