### PR TITLE
Make BackingData public and add ElfFile.from(BackingData)

### DIFF
--- a/src/main/java/net/fornwall/jelf/BackingFile.java
+++ b/src/main/java/net/fornwall/jelf/BackingFile.java
@@ -1,6 +1,6 @@
 package net.fornwall.jelf;
 
-interface BackingFile {
+public interface BackingFile {
 
     void seek(long offset);
     void skip(int bytesToSkip);

--- a/src/main/java/net/fornwall/jelf/ElfFile.java
+++ b/src/main/java/net/fornwall/jelf/ElfFile.java
@@ -513,6 +513,10 @@ public final class ElfFile {
         return new ElfFile(new MappedFile(mappedByteBuffer));
     }
 
+    public static ElfFile from(BackingFile backingFile) throws ElfException {
+        return new ElfFile(backingFile);
+    }
+
     ElfFile(BackingFile backingFile) throws ElfException {
         final ElfParser parser = new ElfParser(this, backingFile);
 


### PR DESCRIPTION
This change allows `ElfFile` to be created from anything that implements `BackingData`, which can be useful to overcome the 2gb size limit of `MappedByteBuffer`.