### PR TITLE
Add equals() and hashCode() to ELF data classes

### DIFF
--- a/src/main/java/net/fornwall/jelf/ElfRelocation.java
+++ b/src/main/java/net/fornwall/jelf/ElfRelocation.java
@@ -1,5 +1,7 @@
 package net.fornwall.jelf;
 
+import java.util.Objects;
+
 /**
  * A relocation connects a symbolic reference with its actual definition.
  * Relocatable files must have information that describes how to modify their
@@ -71,5 +73,20 @@ public final class ElfRelocation {
 	 */
 	public ElfSymbol getSymbol() {
 		return elfFile.getSymbolTableSection().symbols[getSymbolIndex()];
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		ElfRelocation that = (ElfRelocation) o;
+		return r_offset == that.r_offset && r_info == that.r_info;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(r_offset, r_info);
 	}
 }

--- a/src/main/java/net/fornwall/jelf/ElfRelocationAddend.java
+++ b/src/main/java/net/fornwall/jelf/ElfRelocationAddend.java
@@ -1,5 +1,7 @@
 package net.fornwall.jelf;
 
+import java.util.Objects;
+
 /**
  * Relocation is the process of connecting symbolic references with symbolic definitions.
  * For example, when a program calls a function, the associated call instruction must transfer
@@ -88,5 +90,20 @@ public final class ElfRelocationAddend {
      */
     public ElfSymbol getSymbol() {
         return elfFile.getSymbolTableSection().symbols[getSymbolIndex()];
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ElfRelocationAddend that = (ElfRelocationAddend) o;
+        return r_offset == that.r_offset && r_info == that.r_info && r_addend == that.r_addend;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(r_offset, r_info, r_addend);
     }
 }

--- a/src/main/java/net/fornwall/jelf/ElfSection.java
+++ b/src/main/java/net/fornwall/jelf/ElfSection.java
@@ -1,5 +1,8 @@
 package net.fornwall.jelf;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 public class ElfSection {
     public final ElfSectionHeader header;
     protected final ElfParser parser;
@@ -28,4 +31,18 @@ public class ElfSection {
         return result;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ElfSection section = (ElfSection) o;
+        return Objects.equals(header, section.header) && Arrays.equals(getData(), section.getData());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(header, Arrays.hashCode(getData()));
+    }
 }

--- a/src/main/java/net/fornwall/jelf/ElfSectionHeader.java
+++ b/src/main/java/net/fornwall/jelf/ElfSectionHeader.java
@@ -1,5 +1,7 @@
 package net.fornwall.jelf;
 
+import java.util.Objects;
+
 /**
  * Class corresponding to the Elf32_Shdr/Elf64_Shdr struct.
  *
@@ -227,6 +229,21 @@ public class ElfSectionHeader {
         if (sh_name == 0) return null;
         ElfStringTable tbl = elfHeader.getSectionNameStringTable();
         return tbl.get(sh_name);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ElfSectionHeader that = (ElfSectionHeader) o;
+        return sh_name == that.sh_name && sh_type == that.sh_type && sh_flags == that.sh_flags && sh_addr == that.sh_addr && sh_offset == that.sh_offset && sh_size == that.sh_size && sh_link == that.sh_link && sh_info == that.sh_info && sh_addralign == that.sh_addralign && sh_entsize == that.sh_entsize;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sh_name, sh_type, sh_flags, sh_addr, sh_offset, sh_size, sh_link, sh_info, sh_addralign, sh_entsize);
     }
 
     @Override

--- a/src/main/java/net/fornwall/jelf/ElfSegment.java
+++ b/src/main/java/net/fornwall/jelf/ElfSegment.java
@@ -1,6 +1,7 @@
 package net.fornwall.jelf;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Class corresponding to the Elf32_Phdr/Elf64_Phdr struct.
@@ -189,6 +190,21 @@ public class ElfSegment {
 
     public List<ElfNoteSection.ElfNote> notes() {
         return ElfNoteSection.readNotes(parser, p_offset, p_filesz, p_align);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ElfSegment segment = (ElfSegment) o;
+        return p_type == segment.p_type && p_flags == segment.p_flags && p_offset == segment.p_offset && p_vaddr == segment.p_vaddr && p_paddr == segment.p_paddr && p_filesz == segment.p_filesz && p_memsz == segment.p_memsz && p_align == segment.p_align;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(p_type, p_flags, p_offset, p_vaddr, p_paddr, p_filesz, p_memsz, p_align);
     }
 
     @Override

--- a/src/main/java/net/fornwall/jelf/ElfSymbol.java
+++ b/src/main/java/net/fornwall/jelf/ElfSymbol.java
@@ -1,5 +1,7 @@
 package net.fornwall.jelf;
 
+import java.util.Objects;
+
 /**
  * An entry in the {@link ElfSymbolTableSection}, which holds information needed to locate and relocate a program's symbolic definitions and references.
  * <p>
@@ -276,5 +278,20 @@ public final class ElfSymbol {
         }
 
         return "ElfSymbol[name=" + getName() + ", type=" + typeString + ", size=" + st_size + "]";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ElfSymbol elfSymbol = (ElfSymbol) o;
+        return st_name == elfSymbol.st_name && st_value == elfSymbol.st_value && st_size == elfSymbol.st_size && st_info == elfSymbol.st_info && st_other == elfSymbol.st_other && st_shndx == elfSymbol.st_shndx && section_type == elfSymbol.section_type && offset == elfSymbol.offset;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(st_name, st_value, st_size, st_info, st_other, st_shndx, section_type, offset);
     }
 }


### PR DESCRIPTION
Add equals() and hashCode() to ELF data classes so that instances can be compared and used in collections.