### PR TITLE
Revert enabling the Gradle configuration cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .gradle/
 build/
 bin/
+gradle.properties
 
 # Eclipse
 .classpath

--- a/err.txt
+++ b/err.txt
@@ -1,0 +1,23 @@
+Calculating task graph as no cached configuration is available for tasks: publishToSonatype closeAndReleaseSonatypeStagingRepository
+
+1 problem was found storing the configuration cache.
+- Task `:publishMavenJavaPublicationToSonatypeRepository` of type `org.gradle.api.publish.maven.tasks.PublishToMavenRepository`: error writing value of type 'org.gradle.api.publish.maven.tasks.PublishToMavenRepository$RepositorySpec$Configured'
+
+See the complete report at file:///home/fornwall/src/jelf/build/reports/configuration-cache/2tt6h3b2olus3ixk62ayfw0eq/elbroohno5o04ggweiya88bev/configuration-cache-report.html
+
+[Incubating] Problems report is available at: file:///home/fornwall/src/jelf/build/reports/problems/problems-report.html
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Configuration cache state could not be cached: field `repository` of `org.gradle.api.publish.maven.tasks.PublishToMavenRepository$PublishSpec` bean found in field `value` of `org.gradle.internal.Try$Success` bean found in field `result` of `org.gradle.internal.serialization.Cached$Fixed` bean found in field `spec` of task `:publishMavenJavaPublicationToSonatypeRepository` of type `org.gradle.api.publish.maven.tasks.PublishToMavenRepository`: error writing value of type 'org.gradle.api.publish.maven.tasks.PublishToMavenRepository$RepositorySpec$Configured'
+> No staging repository with name sonatype created
+
+* Try:
+> Run with --stacktrace option to get the stack trace.
+> Run with --info or --debug option to get more log output.
+> Run with --scan to get full insights from a Build Scan (powered by Develocity).
+> Get more help at https://help.gradle.org.
+
+BUILD FAILED in 360ms
+Configuration cache entry discarded due to serialization error.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,0 @@
-# Publishing and signing credentials belong in ~/.gradle/gradle.properties or -P flags, not here.
-org.gradle.configuration-cache=true


### PR DESCRIPTION
Publishing to sonatype fails when storing the configuration cache:

```
Configuration cache state could not be cached: field `repository` of
`PublishToMavenRepository$PublishSpec` ... > No staging repository with name sonatype created
```

`publishMavenJavaPublicationToSonatypeRepository` points at a staging repository
that only exists once `initializeSonatypeStagingRepository` has run, so it cannot
be serialized at configuration time.

This was missed because it was only verified with `--dry-run`, which never
reaches the configuration cache store path for that task.

Removes `gradle.properties` again and restores its `.gitignore` entry, so
credentials cannot be committed by accident.

The signing `onlyIf` predicate is kept free of the `Project` instance, so builds
that do not publish can still opt in with `--configuration-cache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)