### PR TITLE
Migrate to com.vanniktech.maven.publish

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,6 @@
 plugins {
-  id("signing")
-  id("maven-publish")
   id("java-library")
-  id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
+  id("com.vanniktech.maven.publish") version "0.37.0"
   id("com.adarshr.test-logger") version "4.0.0"
   id("com.diffplug.spotless") version "8.8.0"
 }
@@ -20,8 +18,6 @@ java {
   group = "net.fornwall"
   version = "0.12.0"
   sourceCompatibility = org.gradle.api.JavaVersion.VERSION_17
-  withJavadocJar()
-  withSourcesJar()
 }
 
 spotless {
@@ -44,63 +40,53 @@ tasks {
   }
 }
 
-// See https://docs.gradle.org/current/userguide/publishing_maven.html
-// and https://github.com/gradle-nexus/publish-plugin
+// See https://vanniktech.github.io/gradle-maven-publish-plugin/central/
 /*
- gpg --keyring secring.gpg --export-secret-keys > ~/.gnupg/secring.gpg
+ Export the signing key once, as gpg 2.1+ no longer keeps a secring.gpg around:
 
- gradle --info \
-   -PsonatypeUsername=xxx \
-   -PsonatypePassword=xxx \
-   -Psigning.keyId=xxx \
-   -Psigning.password=xxx \
-   -Psigning.secretKeyRingFile=$HOME/.gnupg/secring.gpg \
-   publishToSonatype \
-   closeAndReleaseSonatypeStagingRepository
+   gpg --export-secret-keys > ~/.gnupg/secring.gpg
+
+ Then put the credentials in ~/.gradle/gradle.properties, never in this repository:
+
+   mavenCentralUsername=xxx           # user token from https://central.sonatype.com/usertoken
+   mavenCentralPassword=xxx
+   signing.keyId=xxx                  # last 8 characters of the key id
+   signing.password=xxx
+   signing.secretKeyRingFile=/home/user/.gnupg/secring.gpg
+
+ and release with:
+
+   ./gradlew publishAndReleaseToMavenCentral
 */
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-        }
-    }
-}
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  signAllPublications()
 
-publishing {
-  publications {
-    create<MavenPublication>("mavenJava") {
-      from(components["java"])
-      //artifactId = 'jelf'
-      pom {
-        name.set("JElf")
-        description.set("ELF parsing library in java")
-        url.set("https://github.com/fornwall/jelf")
-        licenses {
-          license {
-            name.set("The MIT License")
-            url.set("https://opensource.org/licenses/MIT")
-          }
-        }
-        developers {
-          developer {
-            id.set("fornwall")
-            name.set("Fredrik Fornwall")
-            email.set("fredrik@fornwall.net")
-          }
-        }
-        scm {
-          connection.set("scm:git://github.com/fornwall/jelf.git")
-          developerConnection.set("scm:git:ssh://git@github.com/fornwall/jelf.git")
-          url.set("https://github.com/fornwall/jelf/")
-        }
+  coordinates(group.toString(), "jelf", version.toString())
+
+  pom {
+    name.set("JElf")
+    description.set("ELF parsing library in java")
+    url.set("https://github.com/fornwall/jelf")
+    licenses {
+      license {
+        name.set("The MIT License")
+        url.set("https://opensource.org/licenses/MIT")
       }
     }
+    developers {
+      developer {
+        id.set("fornwall")
+        name.set("Fredrik Fornwall")
+        email.set("fredrik@fornwall.net")
+      }
+    }
+    scm {
+      connection.set("scm:git://github.com/fornwall/jelf.git")
+      developerConnection.set("scm:git:ssh://git@github.com/fornwall/jelf.git")
+      url.set("https://github.com/fornwall/jelf/")
+    }
   }
-}
-
-signing {
-  sign(publishing.publications["mavenJava"])
 }
 
 // Do not sign when only installing into the local maven repository. The decision is stored in a


### PR DESCRIPTION
Releasing 0.12.0 failed at the final step:

```
Execution failed for task ':releaseSonatypeStagingRepository'
> Staging repository is not in desired state [released, not_found]: ... state=closed
```

`io.github.gradle-nexus.publish-plugin` reaches the Central Portal through the
OSSRH staging API compatibility service, which has no release endpoint, so the
deployment has to be released by hand at https://central.sonatype.com/publishing.
That plugin has also not had a release since April 2024.

`com.vanniktech.maven.publish` talks to the portal API directly and can release
as part of the build.

## Changes

- Replaces the `signing`, `maven-publish` and `io.github.gradle-nexus.publish-plugin`
  plugins with `com.vanniktech.maven.publish` 0.37.0, which applies the first two itself.
- Drops `withJavadocJar()`/`withSourcesJar()`, as the plugin adds both.
- Replaces `nexusPublishing`/`publishing`/`signing` with a single `mavenPublishing` block.
- Updates the comment documenting how to release.

The `onlyIf` predicate that skips signing for `publishToMavenLocal` is kept: the
new plugin signs local installs otherwise, which is what #26 fixed.

## Verification

- The generated POM is byte for byte identical to the one the old configuration produced.
- `publishToMavenLocal` installs jar, sources, javadoc, pom and module, and skips signing.
- `signMavenPublication` produces signatures that `gpg --verify` accepts.
- `build` passes with 23 tests and no warnings.

Not verified: the actual upload and release, which can only be exercised by a real
release. Credentials are read from `mavenCentralUsername`/`mavenCentralPassword`
rather than `sonatypeUsername`/`sonatypePassword`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)