### PR TITLE
Resolve relocation symbols through sh_link

### DIFF
--- a/src/main/java/net/fornwall/jelf/ElfRelocation.java
+++ b/src/main/java/net/fornwall/jelf/ElfRelocation.java
@@ -74,6 +74,8 @@ public final class ElfRelocation {
     /**
      * The symbol table that {@link #getSymbolIndex()} indexes into, which is the section linked to
      * by the {@link ElfSectionHeader#sh_link} field of the containing {@link ElfRelocationSection}.
+     *
+     * @throws ElfException if the containing section does not link to a symbol table
      */
     public ElfSymbolTableSection getSymbolTableSection() throws ElfException {
         return ElfSymbolTableSection.linkedFrom(elfFile, sectionHeader);
@@ -82,8 +84,10 @@ public final class ElfRelocation {
     /**
      * The symbol with respect to which the relocation must be made.
      * Use {@link #getSymbolIndex()}} to get the resolved {@link ElfSymbol} from this index.
+     *
+     * @throws ElfException if the containing section does not link to a symbol table
      */
-    public ElfSymbol getSymbol() {
+    public ElfSymbol getSymbol() throws ElfException {
         return getSymbolTableSection().symbols[getSymbolIndex()];
     }
 

--- a/src/main/java/net/fornwall/jelf/ElfRelocation.java
+++ b/src/main/java/net/fornwall/jelf/ElfRelocation.java
@@ -40,13 +40,16 @@ public final class ElfRelocation {
     public final long r_info; // Elf32_Word or Elf64_Xword
 
     private final ElfFile elfFile;
+    /** The header of the {@link ElfRelocationSection} containing this relocation entry. */
+    private final ElfSectionHeader sectionHeader;
 
-    ElfRelocation(ElfParser parser, long offset) {
+    ElfRelocation(ElfParser parser, long offset, ElfSectionHeader sectionHeader) {
         parser.seek(offset);
 
         r_offset = parser.readIntOrLong();
         r_info = parser.readIntOrLong();
         elfFile = parser.elfFile;
+        this.sectionHeader = sectionHeader;
     }
 
     /**
@@ -69,11 +72,19 @@ public final class ElfRelocation {
     }
 
     /**
+     * The symbol table that {@link #getSymbolIndex()} indexes into, which is the section linked to
+     * by the {@link ElfSectionHeader#sh_link} field of the containing {@link ElfRelocationSection}.
+     */
+    public ElfSymbolTableSection getSymbolTableSection() throws ElfException {
+        return ElfSymbolTableSection.linkedFrom(elfFile, sectionHeader);
+    }
+
+    /**
      * The symbol with respect to which the relocation must be made.
      * Use {@link #getSymbolIndex()}} to get the resolved {@link ElfSymbol} from this index.
      */
     public ElfSymbol getSymbol() {
-        return elfFile.getSymbolTableSection().symbols[getSymbolIndex()];
+        return getSymbolTableSection().symbols[getSymbolIndex()];
     }
 
     @Override

--- a/src/main/java/net/fornwall/jelf/ElfRelocationAddend.java
+++ b/src/main/java/net/fornwall/jelf/ElfRelocationAddend.java
@@ -91,6 +91,8 @@ public final class ElfRelocationAddend {
     /**
      * The symbol table that {@link #getSymbolIndex()} indexes into, which is the section linked to by the
      * {@link ElfSectionHeader#sh_link} field of the containing {@link ElfRelocationAddendSection}.
+     *
+     * @throws ElfException if the containing section does not link to a symbol table
      */
     public ElfSymbolTableSection getSymbolTableSection() throws ElfException {
         return ElfSymbolTableSection.linkedFrom(elfFile, sectionHeader);
@@ -99,8 +101,10 @@ public final class ElfRelocationAddend {
     /**
      * The symbol table index, with respect to which the relocation must be made.
      * Use {@link #getSymbolIndex()}} to get the resolved {@link ElfSymbol} from this index.
+     *
+     * @throws ElfException if the containing section does not link to a symbol table
      */
-    public ElfSymbol getSymbol() {
+    public ElfSymbol getSymbol() throws ElfException {
         return getSymbolTableSection().symbols[getSymbolIndex()];
     }
 

--- a/src/main/java/net/fornwall/jelf/ElfRelocationAddend.java
+++ b/src/main/java/net/fornwall/jelf/ElfRelocationAddend.java
@@ -56,14 +56,17 @@ public final class ElfRelocationAddend {
     public final long r_addend; // int32_t or int64_t
 
     private final ElfFile elfFile;
+    /** The header of the {@link ElfRelocationAddendSection} containing this relocation entry. */
+    private final ElfSectionHeader sectionHeader;
 
-    ElfRelocationAddend(ElfParser parser, long offset) {
+    ElfRelocationAddend(ElfParser parser, long offset, ElfSectionHeader sectionHeader) {
         parser.seek(offset);
 
         r_offset = parser.readIntOrLong();
         r_info = parser.readIntOrLong();
         r_addend = parser.readIntOrLong();
         elfFile = parser.elfFile;
+        this.sectionHeader = sectionHeader;
     }
 
     /**
@@ -86,11 +89,19 @@ public final class ElfRelocationAddend {
     }
 
     /**
+     * The symbol table that {@link #getSymbolIndex()} indexes into, which is the section linked to by the
+     * {@link ElfSectionHeader#sh_link} field of the containing {@link ElfRelocationAddendSection}.
+     */
+    public ElfSymbolTableSection getSymbolTableSection() throws ElfException {
+        return ElfSymbolTableSection.linkedFrom(elfFile, sectionHeader);
+    }
+
+    /**
      * The symbol table index, with respect to which the relocation must be made.
      * Use {@link #getSymbolIndex()}} to get the resolved {@link ElfSymbol} from this index.
      */
     public ElfSymbol getSymbol() {
-        return elfFile.getSymbolTableSection().symbols[getSymbolIndex()];
+        return getSymbolTableSection().symbols[getSymbolIndex()];
     }
 
     @Override

--- a/src/main/java/net/fornwall/jelf/ElfRelocationAddendSection.java
+++ b/src/main/java/net/fornwall/jelf/ElfRelocationAddendSection.java
@@ -17,6 +17,8 @@ public final class ElfRelocationAddendSection extends ElfSection {
     /**
      * The symbol table that the {@link ElfRelocationAddend#getSymbolIndex() symbol indexes} of the
      * {@link #relocations} refer to, as specified by the {@link ElfSectionHeader#sh_link} field of this section.
+     *
+     * @throws ElfException if this section does not link to a symbol table
      */
     public ElfSymbolTableSection getSymbolTableSection() throws ElfException {
         return ElfSymbolTableSection.linkedFrom(parser.elfFile, header);

--- a/src/main/java/net/fornwall/jelf/ElfRelocationAddendSection.java
+++ b/src/main/java/net/fornwall/jelf/ElfRelocationAddendSection.java
@@ -10,7 +10,15 @@ public final class ElfRelocationAddendSection extends ElfSection {
         relocations = new ElfRelocationAddend[num_entries];
         for (int i = 0; i < num_entries; i++) {
             final long relOffset = header.sh_offset + (i * header.sh_entsize);
-            relocations[i] = new ElfRelocationAddend(parser, relOffset);
+            relocations[i] = new ElfRelocationAddend(parser, relOffset, header);
         }
+    }
+
+    /**
+     * The symbol table that the {@link ElfRelocationAddend#getSymbolIndex() symbol indexes} of the
+     * {@link #relocations} refer to, as specified by the {@link ElfSectionHeader#sh_link} field of this section.
+     */
+    public ElfSymbolTableSection getSymbolTableSection() throws ElfException {
+        return ElfSymbolTableSection.linkedFrom(parser.elfFile, header);
     }
 }

--- a/src/main/java/net/fornwall/jelf/ElfRelocationSection.java
+++ b/src/main/java/net/fornwall/jelf/ElfRelocationSection.java
@@ -10,7 +10,15 @@ public final class ElfRelocationSection extends ElfSection {
         relocations = new ElfRelocation[num_entries];
         for (int i = 0; i < num_entries; i++) {
             final long relOffset = header.sh_offset + (i * header.sh_entsize);
-            relocations[i] = new ElfRelocation(parser, relOffset);
+            relocations[i] = new ElfRelocation(parser, relOffset, header);
         }
+    }
+
+    /**
+     * The symbol table that the {@link ElfRelocation#getSymbolIndex() symbol indexes} of the {@link #relocations}
+     * refer to, as specified by the {@link ElfSectionHeader#sh_link} field of this section.
+     */
+    public ElfSymbolTableSection getSymbolTableSection() throws ElfException {
+        return ElfSymbolTableSection.linkedFrom(parser.elfFile, header);
     }
 }

--- a/src/main/java/net/fornwall/jelf/ElfRelocationSection.java
+++ b/src/main/java/net/fornwall/jelf/ElfRelocationSection.java
@@ -17,6 +17,8 @@ public final class ElfRelocationSection extends ElfSection {
     /**
      * The symbol table that the {@link ElfRelocation#getSymbolIndex() symbol indexes} of the {@link #relocations}
      * refer to, as specified by the {@link ElfSectionHeader#sh_link} field of this section.
+     *
+     * @throws ElfException if this section does not link to a symbol table
      */
     public ElfSymbolTableSection getSymbolTableSection() throws ElfException {
         return ElfSymbolTableSection.linkedFrom(parser.elfFile, header);

--- a/src/main/java/net/fornwall/jelf/ElfSymbolTableSection.java
+++ b/src/main/java/net/fornwall/jelf/ElfSymbolTableSection.java
@@ -23,4 +23,20 @@ public class ElfSymbolTableSection extends ElfSection {
             symbols[i] = new ElfSymbol(parser, symbolOffset, header.sh_type);
         }
     }
+
+    /**
+     * The symbol table section referred to by the {@link ElfSectionHeader#sh_link} field of the specified
+     * section header, which for relocation sections is the symbol table that relocation entries index into.
+     */
+    static ElfSymbolTableSection linkedFrom(ElfFile elfFile, ElfSectionHeader header) throws ElfException {
+        if (header.sh_link == 0) {
+            throw new ElfException("No linked symbol table for section " + header + " (sh_link is zero)");
+        }
+        ElfSection linkedSection = elfFile.getSection(header.sh_link);
+        if (!(linkedSection instanceof ElfSymbolTableSection symbolTableSection)) {
+            throw new ElfException(
+                    "The section linked from " + header + " is not a symbol table, but " + linkedSection.header);
+        }
+        return symbolTableSection;
+    }
 }

--- a/src/main/java/net/fornwall/jelf/ElfSymbolTableSection.java
+++ b/src/main/java/net/fornwall/jelf/ElfSymbolTableSection.java
@@ -34,15 +34,19 @@ public class ElfSymbolTableSection extends ElfSection {
         // Note that the section header name is not used when describing the sections below, since looking
         // it up may fail for the same type of malformed files that make us end up here in the first place.
         final int linkIndex = header.sh_link;
+        // The sh_link field is unsigned, so print it as such - a value with the highest bit set is a
+        // section index far out of range, and not the negative number it reads as in a signed int.
+        final String linkDescription = " (sh_link=" + Integer.toUnsignedString(linkIndex) + ")";
         if (linkIndex <= 0 || linkIndex >= elfFile.e_shnum) {
-            throw new ElfException("No symbol table linked from section of type 0x" + Long.toHexString(header.sh_type)
-                    + " (sh_link=" + linkIndex + ", number of sections=" + elfFile.e_shnum + ")");
+            throw new ElfException("No symbol table linked from the section of type 0x"
+                    + Integer.toHexString(header.sh_type) + " in a file with " + elfFile.e_shnum + " sections"
+                    + linkDescription);
         }
         ElfSection linkedSection = elfFile.getSection(linkIndex);
         if (!(linkedSection instanceof ElfSymbolTableSection symbolTableSection)) {
-            throw new ElfException("The section linked from section of type 0x" + Long.toHexString(header.sh_type)
-                    + " is not a symbol table, but of type 0x" + Long.toHexString(linkedSection.header.sh_type)
-                    + " (sh_link=" + linkIndex + ")");
+            throw new ElfException("The section linked from the section of type 0x"
+                    + Integer.toHexString(header.sh_type) + " is not a symbol table, but of type 0x"
+                    + Integer.toHexString(linkedSection.header.sh_type) + linkDescription);
         }
         return symbolTableSection;
     }

--- a/src/main/java/net/fornwall/jelf/ElfSymbolTableSection.java
+++ b/src/main/java/net/fornwall/jelf/ElfSymbolTableSection.java
@@ -27,15 +27,22 @@ public class ElfSymbolTableSection extends ElfSection {
     /**
      * The symbol table section referred to by the {@link ElfSectionHeader#sh_link} field of the specified
      * section header, which for relocation sections is the symbol table that relocation entries index into.
+     *
+     * @throws ElfException if sh_link is not the index of a symbol table section
      */
     static ElfSymbolTableSection linkedFrom(ElfFile elfFile, ElfSectionHeader header) throws ElfException {
-        if (header.sh_link == 0) {
-            throw new ElfException("No linked symbol table for section " + header + " (sh_link is zero)");
+        // Note that the section header name is not used when describing the sections below, since looking
+        // it up may fail for the same type of malformed files that make us end up here in the first place.
+        final int linkIndex = header.sh_link;
+        if (linkIndex <= 0 || linkIndex >= elfFile.e_shnum) {
+            throw new ElfException("No symbol table linked from section of type 0x" + Long.toHexString(header.sh_type)
+                    + " (sh_link=" + linkIndex + ", number of sections=" + elfFile.e_shnum + ")");
         }
-        ElfSection linkedSection = elfFile.getSection(header.sh_link);
+        ElfSection linkedSection = elfFile.getSection(linkIndex);
         if (!(linkedSection instanceof ElfSymbolTableSection symbolTableSection)) {
-            throw new ElfException(
-                    "The section linked from " + header + " is not a symbol table, but " + linkedSection.header);
+            throw new ElfException("The section linked from section of type 0x" + Long.toHexString(header.sh_type)
+                    + " is not a symbol table, but of type 0x" + Long.toHexString(linkedSection.header.sh_type)
+                    + " (sh_link=" + linkIndex + ")");
         }
         return symbolTableSection;
     }

--- a/src/test/java/net/fornwall/jelf/BasicTest.java
+++ b/src/test/java/net/fornwall/jelf/BasicTest.java
@@ -126,6 +126,29 @@ class BasicTest {
             Assertions.assertEquals(ElfSymbol.BINDING_GLOBAL, symbol.getBinding());
             Assertions.assertEquals(ElfSymbol.Visibility.STV_DEFAULT, symbol.getVisibility());
 
+            // Relocation entries index into the symbol table linked to by the sh_link field of the
+            // containing relocation section - here .dynsym, and not the .symtab section of the file.
+            List<ElfRelocationSection> relSections = file.sectionsOfType(ElfRelocationSection.class);
+            Assertions.assertEquals(2, relSections.size());
+            Assertions.assertEquals(".rel.dyn", relSections.get(0).header.getName());
+            ElfRelocationSection relPlt = relSections.get(1);
+            Assertions.assertEquals(".rel.plt", relPlt.header.getName());
+            Assertions.assertSame(dynsym, relPlt.getSymbolTableSection());
+            Assertions.assertEquals(83, relPlt.relocations.length);
+
+            // readelf -r:
+            // "Relocation section '.rel.plt' at offset 0x9934 contains 83 entries:
+            //  Offset     Info    Type            Sym.Value  Sym. Name
+            // 0003ceb4  00000216 R_ARM_JUMP_SLOT   00000000   __cxa_atexit"
+            ElfRelocation relocation = relPlt.relocations[0];
+            Assertions.assertEquals(0x0003_ceb4, relocation.r_offset);
+            Assertions.assertEquals(0x0000_0216, relocation.r_info);
+            Assertions.assertEquals(2, relocation.getSymbolIndex());
+            Assertions.assertSame(dynsym, relocation.getSymbolTableSection());
+            Assertions.assertEquals("__cxa_atexit", relocation.getSymbol().getName());
+            // The symbol at the same index in .symtab, which should not be used here:
+            Assertions.assertEquals("$a", symtab.symbols[2].getName());
+
             TestHelper.validateHashTable(file);
 
             ElfDynamicSection dynamic = file.firstSectionByType(ElfDynamicSection.class);
@@ -209,6 +232,33 @@ class BasicTest {
                         0x44
                     },
                     note2.descriptorBytes());
+
+            // This file is stripped and has no .symtab section, so relocations can only be resolved
+            // through the .dynsym section linked to by the sh_link field of the relocation sections.
+            Assertions.assertNull(file.getSymbolTableSection());
+            ElfSymbolTableSection dynsym = file.getDynamicSymbolTableSection();
+            Assertions.assertEquals(".dynsym", dynsym.header.getName());
+
+            List<ElfRelocationAddendSection> relaSections = file.sectionsOfType(ElfRelocationAddendSection.class);
+            Assertions.assertEquals(2, relaSections.size());
+            Assertions.assertEquals(".rela.dyn", relaSections.get(0).header.getName());
+            ElfRelocationAddendSection relaPlt = relaSections.get(1);
+            Assertions.assertEquals(".rela.plt", relaPlt.header.getName());
+            Assertions.assertSame(dynsym, relaPlt.getSymbolTableSection());
+            Assertions.assertEquals(97, relaPlt.relocations.length);
+
+            // readelf -r:
+            // "Relocation section '.rela.plt' at offset 0x3cd0 contains 97 entries:
+            //   Offset          Info           Type           Sym. Value    Sym. Name + Addend
+            // 00000021cc90  000200000007 R_X86_64_JUMP_SLO 0000000000000000 sigprocmask@GLIBC_2.2.5 + 0"
+            ElfRelocationAddend relocation = relaPlt.relocations[0];
+            Assertions.assertEquals(0x0021_cc90, relocation.r_offset);
+            Assertions.assertEquals(0x0002_0000_0007L, relocation.r_info);
+            Assertions.assertEquals(0, relocation.r_addend);
+            Assertions.assertEquals(ElfRelocationTypes.R_X86_64_JUMP_SLOT, relocation.getType());
+            Assertions.assertEquals(2, relocation.getSymbolIndex());
+            Assertions.assertSame(dynsym, relocation.getSymbolTableSection());
+            Assertions.assertEquals("sigprocmask", relocation.getSymbol().getName());
 
             TestHelper.validateHashTable(file);
         });

--- a/src/test/java/net/fornwall/jelf/BasicTest.java
+++ b/src/test/java/net/fornwall/jelf/BasicTest.java
@@ -592,4 +592,58 @@ class BasicTest {
             }
         });
     }
+
+    @Test
+    void testRelocationWithInvalidSymbolTableLink() throws Exception {
+        // No linked section:
+        assertRelocationSymbolLookupFails(0, false);
+        // No linked section, in a file which also has no section name string table:
+        assertRelocationSymbolLookupFails(0, true);
+        // The .interp section, which is not a symbol table:
+        assertRelocationSymbolLookupFails(1, false);
+        // Section indexes past the end of the section header table:
+        assertRelocationSymbolLookupFails(Short.MAX_VALUE, false);
+        assertRelocationSymbolLookupFails(Integer.MIN_VALUE, false);
+    }
+
+    /**
+     * Patch the sh_link field of the .rela.plt section of the linux_amd64_bindash file to the specified
+     * invalid value, and assert that resolving relocation symbols then fails with an {@link ElfException}.
+     */
+    private static void assertRelocationSymbolLookupFails(int shLink, boolean clearSectionNameStringTable)
+            throws Exception {
+        try (InputStream in = BasicTest.class.getResourceAsStream("/linux_amd64_bindash")) {
+            Assertions.assertNotNull(in);
+            byte[] data = in.readAllBytes();
+
+            ElfFile originalFile = ElfFile.from(data);
+            Assertions.assertFalse(originalFile.is32Bits());
+            int sectionIndex = -1;
+            for (int i = 1; i < originalFile.e_shnum; i++) {
+                if (".rela.plt".equals(originalFile.getSection(i).header.getName())) {
+                    sectionIndex = i;
+                }
+            }
+            Assertions.assertNotEquals(-1, sectionIndex);
+            ByteOrder order = originalFile.ei_data == ElfFile.DATA_LSB ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN;
+
+            // In a 64-bit section header the sh_link field is preceded by the 4 byte sh_name and sh_type
+            // fields and the 8 byte sh_flags, sh_addr, sh_offset and sh_size fields:
+            int shLinkOffset = (int) originalFile.e_shoff + sectionIndex * originalFile.e_shentsize + 40;
+            ByteBuffer.wrap(data, shLinkOffset, Integer.BYTES).order(order).putInt(shLink);
+            if (clearSectionNameStringTable) {
+                // The e_shstrndx field is the last one of the 64 byte elf header:
+                ByteBuffer.wrap(data, 62, Short.BYTES).order(order).putShort((short) 0);
+            }
+
+            ElfFile patchedFile = ElfFile.from(data);
+            ElfRelocationAddendSection relaPlt = (ElfRelocationAddendSection) patchedFile.getSection(sectionIndex);
+            Assertions.assertEquals(shLink, relaPlt.header.sh_link);
+            Assertions.assertThrows(ElfException.class, relaPlt::getSymbolTableSection);
+
+            ElfRelocationAddend relocation = relaPlt.relocations[0];
+            Assertions.assertThrows(ElfException.class, relocation::getSymbolTableSection);
+            Assertions.assertThrows(ElfException.class, relocation::getSymbol);
+        }
+    }
 }

--- a/src/test/java/net/fornwall/jelf/BasicTest.java
+++ b/src/test/java/net/fornwall/jelf/BasicTest.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 class BasicTest {
 
@@ -595,23 +596,31 @@ class BasicTest {
 
     @Test
     void testRelocationWithInvalidSymbolTableLink() throws Exception {
+        // The linux_amd64_bindash file has 27 sections, and its .rela.plt section is of type SHT_RELA (0x4).
+        String noSymbolTable = "No symbol table linked from the section of type 0x4 in a file with 27 sections";
+
         // No linked section:
-        assertRelocationSymbolLookupFails(0, false);
+        assertRelocationSymbolLookupFails(0, false, noSymbolTable + " (sh_link=0)");
         // No linked section, in a file which also has no section name string table:
-        assertRelocationSymbolLookupFails(0, true);
-        // The .interp section, which is not a symbol table:
-        assertRelocationSymbolLookupFails(1, false);
-        // Section indexes past the end of the section header table:
-        assertRelocationSymbolLookupFails(Short.MAX_VALUE, false);
-        assertRelocationSymbolLookupFails(Integer.MIN_VALUE, false);
+        assertRelocationSymbolLookupFails(0, true, noSymbolTable + " (sh_link=0)");
+        // Section indexes past the end of the section header table, the last one having the highest bit set:
+        assertRelocationSymbolLookupFails(Short.MAX_VALUE, false, noSymbolTable + " (sh_link=32767)");
+        assertRelocationSymbolLookupFails(Integer.MIN_VALUE, false, noSymbolTable + " (sh_link=2147483648)");
+        // The .interp section, which is of type SHT_PROGBITS (0x1) and not a symbol table:
+        assertRelocationSymbolLookupFails(
+                1,
+                false,
+                "The section linked from the section of type 0x4 is not a symbol table,"
+                        + " but of type 0x1 (sh_link=1)");
     }
 
     /**
      * Patch the sh_link field of the .rela.plt section of the linux_amd64_bindash file to the specified
-     * invalid value, and assert that resolving relocation symbols then fails with an {@link ElfException}.
+     * invalid value, and assert that resolving relocation symbols then fails with an {@link ElfException}
+     * having the specified message.
      */
-    private static void assertRelocationSymbolLookupFails(int shLink, boolean clearSectionNameStringTable)
-            throws Exception {
+    private static void assertRelocationSymbolLookupFails(
+            int shLink, boolean clearSectionNameStringTable, String expectedMessage) throws Exception {
         try (InputStream in = BasicTest.class.getResourceAsStream("/linux_amd64_bindash")) {
             Assertions.assertNotNull(in);
             byte[] data = in.readAllBytes();
@@ -639,11 +648,13 @@ class BasicTest {
             ElfFile patchedFile = ElfFile.from(data);
             ElfRelocationAddendSection relaPlt = (ElfRelocationAddendSection) patchedFile.getSection(sectionIndex);
             Assertions.assertEquals(shLink, relaPlt.header.sh_link);
-            Assertions.assertThrows(ElfException.class, relaPlt::getSymbolTableSection);
-
             ElfRelocationAddend relocation = relaPlt.relocations[0];
-            Assertions.assertThrows(ElfException.class, relocation::getSymbolTableSection);
-            Assertions.assertThrows(ElfException.class, relocation::getSymbol);
+
+            for (Executable symbolLookup : List.<Executable>of(
+                    relaPlt::getSymbolTableSection, relocation::getSymbolTableSection, relocation::getSymbol)) {
+                ElfException e = Assertions.assertThrows(ElfException.class, symbolLookup);
+                Assertions.assertEquals(expectedMessage, e.getMessage());
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #56.

`ElfRelocation#getSymbol()` and `ElfRelocationAddend#getSymbol()` resolved the symbol index against `ElfFile#getSymbolTableSection()`, i.e. the first `SHT_SYMTAB` section of the file. A relocation entry's symbol index is instead relative to the symbol table given by the `sh_link` field of the section containing it.

For dynamic relocation sections (`.rel.dyn`, `.rela.dyn`, `.rel.plt`, `.rela.plt`), which link to `.dynsym`, this meant:

- the wrong symbol was returned when the file also has a `.symtab` — e.g. for the `android_arm_libncurses` test file, the first `.rel.plt` entry resolved to `$a` (`.symtab` index 2) rather than `__cxa_atexit` (`.dynsym` index 2),
- a `NullPointerException` for stripped files with no `.symtab` at all, such as the `linux_amd64_bindash` test file.

## Changes

- The containing `ElfSectionHeader` is passed down to `ElfRelocation`/`ElfRelocationAddend`, which now resolve the symbol table through `sh_link`.
- New public `getSymbolTableSection()` on `ElfRelocation`, `ElfRelocationAddend`, `ElfRelocationSection` and `ElfRelocationAddendSection`, throwing an `ElfException` if `sh_link` is zero or does not point at a symbol table.
- Tests covering both the "wrong table" case (`android_arm_libncurses`) and the "no `.symtab` at all" case (`linux_amd64_bindash`).

Relocations in relocatable object files (the existing `objectFile.o` / `objectFile-64.o` tests) link to `.symtab` and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)