### PR TITLE
Read the note descriptor before interpreting it as a GNU ABI tag

### DIFF
--- a/src/main/java/net/fornwall/jelf/ElfNoteSection.java
+++ b/src/main/java/net/fornwall/jelf/ElfNoteSection.java
@@ -134,13 +134,7 @@ public class ElfNoteSection extends ElfSection {
         }
 
         public GnuAbiDescriptor descriptorAsGnuAbi() {
-            if (descriptorBytes.length < 16) {
-                return null;
-            }
-
-            ByteBuffer buf = ByteBuffer.wrap(descriptorBytes)
-                    .order(ei_data == ElfFile.DATA_LSB ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
-            return new GnuAbiDescriptor(buf.getInt(0), buf.getInt(4), buf.getInt(8), buf.getInt(12));
+            return gnuAbiDescriptorFrom(name, type, descriptorBytes, ei_data);
         }
 
         @Override
@@ -163,6 +157,27 @@ public class ElfNoteSection extends ElfSection {
     }
 
     static final int NHDR_SIZE = 3 * Integer.BYTES;
+
+    /**
+     * The size of the descriptor of a {@link #NT_GNU_ABI_TAG} note, which consists of four words.
+     */
+    static final int GNU_ABI_DESCRIPTOR_SIZE = 4 * Integer.BYTES;
+
+    /**
+     * The descriptor of the specified note interpreted as a {@link #NT_GNU_ABI_TAG} one, or null if the
+     * note is not a GNU ABI tag note or if its descriptor is too small to contain one.
+     */
+    private static GnuAbiDescriptor gnuAbiDescriptorFrom(String name, int type, byte[] descriptorBytes, byte ei_data) {
+        if (type != NT_GNU_ABI_TAG
+                || !ElfNoteTypes.ELF_NOTE_GNU.equals(name)
+                || descriptorBytes.length < GNU_ABI_DESCRIPTOR_SIZE) {
+            return null;
+        }
+
+        ByteBuffer buffer = ByteBuffer.wrap(descriptorBytes)
+                .order(ei_data == ElfFile.DATA_LSB ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
+        return new GnuAbiDescriptor(buffer.getInt(0), buffer.getInt(4), buffer.getInt(8), buffer.getInt(12));
+    }
 
     public final /* uint32_t */ int n_namesz;
     public final /* uint32_t */ int n_descsz;
@@ -202,14 +217,6 @@ public class ElfNoteSection extends ElfSection {
         }
 
         descriptorBytes = new byte[n_descsz];
-
-        if (n_type == NT_GNU_ABI_TAG) {
-            gnuAbiDescriptor =
-                    new GnuAbiDescriptor(parser.readInt(), parser.readInt(), parser.readInt(), parser.readInt());
-        } else {
-            gnuAbiDescriptor = null;
-        }
-
         bytesRead = parser.read(descriptorBytes);
 
         if (bytesRead != n_descsz) {
@@ -223,6 +230,7 @@ public class ElfNoteSection extends ElfSection {
         }
 
         n_name = new String(nameBytes, 0, nameLen);
+        gnuAbiDescriptor = gnuAbiDescriptorFrom(n_name, n_type, descriptorBytes, parser.elfFile.ei_data);
     }
 
     public String getName() {

--- a/src/main/java/net/fornwall/jelf/ElfNoteSection.java
+++ b/src/main/java/net/fornwall/jelf/ElfNoteSection.java
@@ -11,6 +11,9 @@ public class ElfNoteSection extends ElfSection {
 
     /**
      * A possible value of the {@link #n_type} where the description should contain {@link GnuAbiDescriptor}.
+     * <p>
+     * Note types are specific to the note owner, so this value only has this meaning in a note with the
+     * "GNU" name - it is for example NT_PRSTATUS in a note owned by "CORE".
      */
     public static final int NT_GNU_ABI_TAG = 1;
     /**
@@ -133,6 +136,10 @@ public class ElfNoteSection extends ElfSection {
             return new String(descriptorBytes);
         }
 
+        /**
+         * The descriptor of this note interpreted as a {@link GnuAbiDescriptor}, or null if this is not a
+         * {@link #NT_GNU_ABI_TAG} note of the "GNU" owner, or if its descriptor is too small to contain one.
+         */
         public GnuAbiDescriptor descriptorAsGnuAbi() {
             return gnuAbiDescriptorFrom(name, type, descriptorBytes, ei_data);
         }
@@ -245,6 +252,10 @@ public class ElfNoteSection extends ElfSection {
         return new String(descriptorBytes);
     }
 
+    /**
+     * The descriptor of the first note of this section interpreted as a {@link GnuAbiDescriptor}, or null if
+     * that is not a {@link #NT_GNU_ABI_TAG} note of the "GNU" owner, or if its descriptor is too small.
+     */
     public GnuAbiDescriptor descriptorAsGnuAbi() {
         return gnuAbiDescriptor;
     }

--- a/src/test/java/net/fornwall/jelf/BasicTest.java
+++ b/src/test/java/net/fornwall/jelf/BasicTest.java
@@ -554,7 +554,15 @@ class BasicTest {
     @Test
     void testNoteSectionDescriptorIsThatOfFirstNote() throws Exception {
         List<String> fileNames = Arrays.asList(
-                "android_arm_libncurses", "go_amd64_notes", "linux_amd64_bindash", "netbsd_amd64_yes", "usr-bin-yes");
+                "android_arm_libncurses",
+                "android_arm_tset",
+                "go_amd64_notes",
+                "linux_amd64_bindash",
+                "little-endian-test",
+                // Has a .note.gnu.property section with two notes in it:
+                "objectFile-64.o",
+                "netbsd_amd64_yes",
+                "usr-bin-yes");
 
         for (String fileName : fileNames) {
             TestHelper.parseFile(fileName, file -> {
@@ -577,39 +585,75 @@ class BasicTest {
 
     @Test
     void testGnuAbiNoteWithTooSmallDescriptor() throws Exception {
-        // A NT_GNU_ABI_TAG note descriptor needs four words - a smaller one cannot be interpreted as one:
-        assertGnuAbiDescriptorIsNull(ElfNoteSection.GNU_ABI_DESCRIPTOR_SIZE - Integer.BYTES);
-        assertGnuAbiDescriptorIsNull(0);
+        // A NT_GNU_ABI_TAG note descriptor needs four words - a smaller one cannot be interpreted as one.
+        // Note that the notes() of the patched section cannot be read, as the descriptor size no longer
+        // matches the section size, so only the note section itself is validated here:
+        for (int descsz : new int[] {ElfNoteSection.GNU_ABI_DESCRIPTOR_SIZE - Integer.BYTES, 0}) {
+            ElfNoteSection patchedSection = patchedAbiTagNoteSection(NOTE_DESCSZ_OFFSET, intBytes(descsz));
+            Assertions.assertEquals(descsz, patchedSection.n_descsz);
+            Assertions.assertEquals(descsz, patchedSection.descriptorBytes().length);
+            Assertions.assertNull(patchedSection.descriptorAsGnuAbi());
+        }
+    }
+
+    @Test
+    void testGnuAbiDescriptorRequiresGnuAbiTagNote() throws Exception {
+        // A note of another type than NT_GNU_ABI_TAG, here NT_GNU_BUILD_ID:
+        assertNoGnuAbiDescriptor(NOTE_TYPE_OFFSET, intBytes(NT_GNU_BUILD_ID));
+        // A note with another owner than "GNU", even when using the NT_GNU_ABI_TAG note type, which is
+        // only defined for GNU notes - it is for example NT_PRSTATUS in a "CORE" note of a core dump:
+        assertNoGnuAbiDescriptor(NOTE_NAME_OFFSET, new byte[] {'C', 'O', 'R', 'E'});
+    }
+
+    private static void assertNoGnuAbiDescriptor(int offsetInNote, byte[] patchedBytes) throws Exception {
+        ElfNoteSection patchedSection = patchedAbiTagNoteSection(offsetInNote, patchedBytes);
+        Assertions.assertNull(patchedSection.descriptorAsGnuAbi());
+        Assertions.assertNull(patchedSection.notes().get(0).descriptorAsGnuAbi());
+    }
+
+    /** The offset of the n_descsz field inside a note, which follows the n_namesz field. */
+    private static final int NOTE_DESCSZ_OFFSET = Integer.BYTES;
+    /** The offset of the n_type field inside a note, which follows the n_namesz and n_descsz fields. */
+    private static final int NOTE_TYPE_OFFSET = 2 * Integer.BYTES;
+    /** The offset of the note name inside a note, which follows the note header. */
+    private static final int NOTE_NAME_OFFSET = ElfNoteSection.NHDR_SIZE;
+
+    private static byte[] intBytes(int value) {
+        // All of the test files, including the linux_amd64_bindash one patched below, are little-endian:
+        return ByteBuffer.allocate(Integer.BYTES)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .putInt(value)
+                .array();
     }
 
     /**
-     * Patch the descriptor size of the NT_GNU_ABI_TAG note of the linux_amd64_bindash file to the specified
-     * too small size, and assert that the descriptor then is not interpreted as an ABI tag descriptor.
+     * Patch the specified bytes into the NT_GNU_ABI_TAG note of the linux_amd64_bindash file, which has a
+     * valid GNU ABI tag descriptor before being patched, and return the note section of the patched file.
      */
-    private static void assertGnuAbiDescriptorIsNull(int descsz) throws Exception {
+    private static ElfNoteSection patchedAbiTagNoteSection(int offsetInNote, byte[] patchedBytes) throws Exception {
         try (InputStream in = BasicTest.class.getResourceAsStream("/linux_amd64_bindash")) {
             Assertions.assertNotNull(in);
             byte[] data = in.readAllBytes();
 
             ElfFile originalFile = ElfFile.from(data);
-            ElfNoteSection abiTagSection = originalFile.sectionsOfType(ElfNoteSection.class).stream()
-                    .filter(section -> section.n_type == NT_GNU_ABI_TAG)
-                    .findFirst()
-                    .orElseThrow();
+            Assertions.assertEquals(ElfFile.DATA_LSB, originalFile.ei_data);
+            int abiTagSectionIndex = -1;
+            for (int i = 1; i < originalFile.e_shnum; i++) {
+                if (originalFile.getSection(i) instanceof ElfNoteSection noteSection
+                        && noteSection.n_type == NT_GNU_ABI_TAG) {
+                    abiTagSectionIndex = i;
+                }
+            }
+            Assertions.assertNotEquals(-1, abiTagSectionIndex);
+
+            ElfNoteSection abiTagSection = (ElfNoteSection) originalFile.getSection(abiTagSectionIndex);
+            Assertions.assertEquals(ELF_NOTE_GNU, abiTagSection.getName());
             Assertions.assertNotNull(abiTagSection.descriptorAsGnuAbi());
+            Assertions.assertNotNull(abiTagSection.notes().get(0).descriptorAsGnuAbi());
 
-            // The n_descsz field follows the n_namesz field at the start of the note:
-            int descszOffset = (int) abiTagSection.header.sh_offset + Integer.BYTES;
-            ByteOrder order = originalFile.ei_data == ElfFile.DATA_LSB ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN;
-            ByteBuffer.wrap(data, descszOffset, Integer.BYTES).order(order).putInt(descsz);
-
-            ElfNoteSection patchedSection = ElfFile.from(data).sectionsOfType(ElfNoteSection.class).stream()
-                    .filter(section -> section.n_type == NT_GNU_ABI_TAG)
-                    .findFirst()
-                    .orElseThrow();
-            Assertions.assertEquals(descsz, patchedSection.n_descsz);
-            Assertions.assertEquals(descsz, patchedSection.descriptorBytes().length);
-            Assertions.assertNull(patchedSection.descriptorAsGnuAbi());
+            int patchOffset = (int) abiTagSection.header.sh_offset + offsetInNote;
+            System.arraycopy(patchedBytes, 0, data, patchOffset, patchedBytes.length);
+            return (ElfNoteSection) ElfFile.from(data).getSection(abiTagSectionIndex);
         }
     }
 }

--- a/src/test/java/net/fornwall/jelf/BasicTest.java
+++ b/src/test/java/net/fornwall/jelf/BasicTest.java
@@ -180,6 +180,9 @@ class BasicTest {
             Assertions.assertEquals(2, note1.descriptorAsGnuAbi().majorVersion);
             Assertions.assertEquals(6, note1.descriptorAsGnuAbi().minorVersion);
             Assertions.assertEquals(24, note1.descriptorAsGnuAbi().subminorVersion);
+            // readelf -x .note.ABI-tag, the 16 descriptor bytes following the "GNU\0" note name:
+            Assertions.assertArrayEquals(
+                    new byte[] {0, 0, 0, 0, 2, 0, 0, 0, 6, 0, 0, 0, 24, 0, 0, 0}, note1.descriptorBytes());
             Assertions.assertEquals(".note.gnu.build-id", note2.header.getName());
             Assertions.assertEquals("GNU", note2.getName());
             Assertions.assertEquals(ElfNoteSection.NT_GNU_BUILD_ID, note2.n_type);
@@ -541,5 +544,72 @@ class BasicTest {
                 Assertions.assertEquals(sectionNote, segmentNote);
             }
         });
+    }
+
+    /**
+     * The descriptor of a note section should be the same one as of the first note in the section - which
+     * used to not be the case for {@link ElfNoteSection#NT_GNU_ABI_TAG} notes, where reading the descriptor
+     * as a {@link ElfNoteSection.GnuAbiDescriptor} advanced past the descriptor before it was read.
+     */
+    @Test
+    void testNoteSectionDescriptorIsThatOfFirstNote() throws Exception {
+        List<String> fileNames = Arrays.asList(
+                "android_arm_libncurses", "go_amd64_notes", "linux_amd64_bindash", "netbsd_amd64_yes", "usr-bin-yes");
+
+        for (String fileName : fileNames) {
+            TestHelper.parseFile(fileName, file -> {
+                List<ElfNoteSection> noteSections = file.sectionsOfType(ElfNoteSection.class);
+                Assertions.assertFalse(noteSections.isEmpty());
+
+                for (ElfNoteSection noteSection : noteSections) {
+                    ElfNoteSection.ElfNote firstNote = noteSection.notes().get(0);
+                    Assertions.assertEquals(noteSection.getName(), firstNote.name);
+                    Assertions.assertEquals(noteSection.n_namesz, firstNote.namesz);
+                    Assertions.assertEquals(noteSection.n_type, firstNote.type);
+                    Assertions.assertEquals(noteSection.n_descsz, firstNote.descriptorBytes().length);
+                    Assertions.assertArrayEquals(firstNote.descriptorBytes(), noteSection.descriptorBytes());
+                    Assertions.assertEquals(firstNote.descriptorAsString(), noteSection.descriptorAsString());
+                    Assertions.assertEquals(firstNote.descriptorAsGnuAbi(), noteSection.descriptorAsGnuAbi());
+                }
+            });
+        }
+    }
+
+    @Test
+    void testGnuAbiNoteWithTooSmallDescriptor() throws Exception {
+        // A NT_GNU_ABI_TAG note descriptor needs four words - a smaller one cannot be interpreted as one:
+        assertGnuAbiDescriptorIsNull(ElfNoteSection.GNU_ABI_DESCRIPTOR_SIZE - Integer.BYTES);
+        assertGnuAbiDescriptorIsNull(0);
+    }
+
+    /**
+     * Patch the descriptor size of the NT_GNU_ABI_TAG note of the linux_amd64_bindash file to the specified
+     * too small size, and assert that the descriptor then is not interpreted as an ABI tag descriptor.
+     */
+    private static void assertGnuAbiDescriptorIsNull(int descsz) throws Exception {
+        try (InputStream in = BasicTest.class.getResourceAsStream("/linux_amd64_bindash")) {
+            Assertions.assertNotNull(in);
+            byte[] data = in.readAllBytes();
+
+            ElfFile originalFile = ElfFile.from(data);
+            ElfNoteSection abiTagSection = originalFile.sectionsOfType(ElfNoteSection.class).stream()
+                    .filter(section -> section.n_type == NT_GNU_ABI_TAG)
+                    .findFirst()
+                    .orElseThrow();
+            Assertions.assertNotNull(abiTagSection.descriptorAsGnuAbi());
+
+            // The n_descsz field follows the n_namesz field at the start of the note:
+            int descszOffset = (int) abiTagSection.header.sh_offset + Integer.BYTES;
+            ByteOrder order = originalFile.ei_data == ElfFile.DATA_LSB ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN;
+            ByteBuffer.wrap(data, descszOffset, Integer.BYTES).order(order).putInt(descsz);
+
+            ElfNoteSection patchedSection = ElfFile.from(data).sectionsOfType(ElfNoteSection.class).stream()
+                    .filter(section -> section.n_type == NT_GNU_ABI_TAG)
+                    .findFirst()
+                    .orElseThrow();
+            Assertions.assertEquals(descsz, patchedSection.n_descsz);
+            Assertions.assertEquals(descsz, patchedSection.descriptorBytes().length);
+            Assertions.assertNull(patchedSection.descriptorAsGnuAbi());
+        }
     }
 }


### PR DESCRIPTION
Fixes #55.

The `ElfNoteSection` constructor read the four words of a `NT_GNU_ABI_TAG` descriptor straight from the parser *before* reading the descriptor bytes, so the parser cursor had already advanced 16 bytes when `descriptorBytes` was read. `descriptorBytes()`, `descriptorAsString()` and `equals()` of such a note section therefore returned whatever followed the note in the file.

For `linux_amd64_bindash`, whose `.note.ABI-tag` section is `sh_offset=0x254`, `sh_size=0x20` with the descriptor at `0x264`, `descriptorBytes()` returned the 16 bytes at `0x274` — the note header of the following `.note.gnu.build-id` section — instead of the ABI tag descriptor.

The bug was not limited to GNU notes: it applied to any note section with `n_type == 1`, including `NT_NETBSD_IDENT` notes such as the one in the `netbsd_amd64_yes` test file, where the descriptor was read from past the end of the section entirely.

## Changes

- The descriptor bytes are read first, and the `GnuAbiDescriptor` is constructed from those, sharing one helper with `ElfNote#descriptorAsGnuAbi()`.
- That helper now also requires the note to be a `NT_GNU_ABI_TAG` note of the `"GNU"` owner. This is a behavior change for `ElfNote#descriptorAsGnuAbi()`, which previously returned a descriptor for any note with at least 16 descriptor bytes — a GNU build id or a Go build id note would be reported as an ABI tag with garbage version numbers. Note types are namespaced by the note owner, so the owner has to be part of the check: `NT_GNU_ABI_TAG` is 1, which is `NT_PRSTATUS` in a `"CORE"` note of a core dump and `NT_NETBSD_IDENT` in a `"NetBSD"` one.
- Tests: the descriptor of a note section is asserted to be the one of the first note in the section across the note-carrying test files (including `objectFile-64.o`, whose `.note.gnu.property` section holds two notes), the descriptor bytes of the `linux_amd64_bindash` ABI tag note are asserted explicitly, and the descriptor size, note type and note owner requirements are covered by patching the ABI tag note of that file.
- Documented when the two public `descriptorAsGnuAbi()` methods return null, and that `NT_GNU_ABI_TAG` only has that meaning for `"GNU"` notes.

Verified that reintroducing the old ordering fails `testLinuxAmd64BinDash` and `testNoteSectionDescriptorIsThatOfFirstNote`, and that dropping the type/owner check fails `testGnuAbiDescriptorRequiresGnuAbiTagNote`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)